### PR TITLE
close #115 add prefix to bdc assets;

### DIFF
--- a/bdc_catalog/jsonschemas/item-assets.json
+++ b/bdc_catalog/jsonschemas/item-assets.json
@@ -27,7 +27,7 @@
                 "updated",
                 "roles",
                 "checksum:multihash",
-                "size"
+                "bdc:size"
             ],
             "properties": {
                 "href": {
@@ -94,12 +94,12 @@
                     "type": "string",
                     "pattern": "^[a-f0-9]+$"
                 },
-                "size": {
+                "bdc:size": {
                     "title": "Asset size",
                     "description": "Size of the referenced asset (in bytes)",
                     "type": "number"
                 },
-                "raster_size": {
+                "bdc:raster_size": {
                     "title": "Asset raster X, Y size",
                     "description": "If the asset is a raster file, this field describes the dimensions of the raster.",
                     "type": "object",
@@ -114,7 +114,7 @@
                         }
                     }
                 },
-                "chunk_size": {
+                "bdc:chunk_size": {
                     "title": "Asset chunk X, Y size",
                     "type": "object",
                     "properties": {
@@ -146,7 +146,7 @@
                 "updated": "2020-07-01T23:59:59",
                 "roles": ["thumbnail"],
                 "checksum:multihash":  "10dcba59b727a08f937a235d759d894d61c14b3dd237edb638189c281902a6fb",
-                "size": 2048
+                "bdc:size": 2048
             }
         }
     ]


### PR DESCRIPTION
close #115

The file `bdc_catalog/jsonschemas/item-assets.json` were written using *CR+LF* (Windows only). I changed now for LF (Linux)