### PR TITLE
Add custom data type to validate JSONB columns with JSONSchemas

### DIFF
--- a/bdc_catalog/config.py
+++ b/bdc_catalog/config.py
@@ -7,6 +7,7 @@
 #
 
 """Configuration file for BDC-Catalog."""
+import os
 
 BDC_CATALOG_SCHEMA = 'bdc'
 """Define the database schema prefix for BDC-Catalog models.
@@ -14,3 +15,6 @@ BDC_CATALOG_SCHEMA = 'bdc'
 TODO: Get it as environment variable. We should take care of migrations schema before do it.
       Check the issue https://github.com/brazil-data-cube/bdc-catalog/issues/123
 """
+
+JSONSCHEMAS_HOST = os.getenv('JSONSCHEMAS_HOST', 'brazildatacube.org')
+"""Define the hostname for BDC Catalog schemas."""

--- a/bdc_catalog/ext.py
+++ b/bdc_catalog/ext.py
@@ -11,7 +11,9 @@
 from bdc_db.ext import BrazilDataCubeDB
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from invenio_jsonschemas import InvenioJSONSchemas
 
+from . import config
 from .cli import cli
 from .models.base_sql import db as _db
 
@@ -31,6 +33,7 @@ class BDCCatalog:
 
     # Reference to BrazilDataCubeDB app instance
     _db_ext = None
+    schemas: InvenioJSONSchemas = None
 
     def __init__(self, app=None):
         """Initialize the catalog extension.
@@ -47,10 +50,18 @@ class BDCCatalog:
         Args:
             app: Flask application
         """
+        self.init_config(app)
+
         self._db_ext = BrazilDataCubeDB(app)
+        self.schemas = InvenioJSONSchemas(app, entry_point_group='bdc.schemas')
         app.extensions['bdc-catalog'] = self
 
         app.cli.add_command(cli)
+
+    def init_config(self, app: Flask):
+        """Initialize configuration file."""
+        for config_key in dir(config):
+            app.config.setdefault(config_key, getattr(config, config_key))
 
     @property
     def db(self) -> SQLAlchemy:

--- a/bdc_catalog/jsonschemas/__init__.py
+++ b/bdc_catalog/jsonschemas/__init__.py
@@ -1,0 +1,9 @@
+#
+# This file is part of Brazil Data Cube Database module.
+# Copyright (C) 2019 INPE.
+#
+# Brazil Data Cube Database module is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+
+"""Define module init for JSONSchemas."""

--- a/bdc_catalog/models/band.py
+++ b/bdc_catalog/models/band.py
@@ -10,10 +10,10 @@
 
 from sqlalchemy import (Column, Enum, ForeignKey, Index, Integer, Numeric,
                         PrimaryKeyConstraint, String, Text)
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
 from ..config import BDC_CATALOG_SCHEMA
+from ..types import JSONSchemaType
 from .base_sql import BaseModel
 from .collection import Collection
 
@@ -46,7 +46,9 @@ class Band(BaseModel):
     resolution_unit_id = Column(ForeignKey(f'{BDC_CATALOG_SCHEMA}.resolution_unit.id', onupdate='CASCADE', ondelete='CASCADE'))
     data_type = Column(enum_data_type)
     mime_type_id = Column(ForeignKey(f'{BDC_CATALOG_SCHEMA}.mime_type.id', onupdate='CASCADE', ondelete='CASCADE'))
-    _metadata = Column('metadata', JSONB, comment='Follow the JSONSchema @jsonschemas/band-metadata.json')
+    _metadata = Column('metadata',
+                       JSONSchemaType('band-metadata.json'),
+                       comment='Follow the JSONSchema @jsonschemas/band-metadata.json')
 
     collection = relationship(Collection)
     resolution_unit = relationship('ResolutionUnit')

--- a/bdc_catalog/models/collection.py
+++ b/bdc_catalog/models/collection.py
@@ -13,10 +13,10 @@ from lccs_db.models import LucClassificationSystem
 from sqlalchemy import (TIMESTAMP, Boolean, Column, Enum, ForeignKey, Index,
                         Integer, PrimaryKeyConstraint, SmallInteger, String,
                         Text, UniqueConstraint)
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
 from ..config import BDC_CATALOG_SCHEMA
+from ..types import JSONSchemaType
 from .base_sql import BaseModel, db
 from .provider import Provider
 
@@ -34,14 +34,16 @@ class Collection(BaseModel):
     name = Column(String(255), nullable=False, comment='Collection name internally.')
     title = Column(String(255), nullable=False, comment='A human-readable string naming for collection.')
     description = Column(Text)
-    temporal_composition_schema = Column(JSONB, comment='Follow the JSONSchema @jsonschemas/collection-temporal-composition-schema.json')
+    temporal_composition_schema = Column(
+        JSONSchemaType('collection-temporal-composition-schema.json'),
+        comment='Follow the JSONSchema @jsonschemas/collection-temporal-composition-schema.json')
     composite_function_id = Column(
         ForeignKey(f'{BDC_CATALOG_SCHEMA}.composite_functions.id', onupdate='CASCADE', ondelete='CASCADE'),
         comment='Function schema identifier. Used for data cubes.')
     grid_ref_sys_id = Column(ForeignKey(f'{BDC_CATALOG_SCHEMA}.grid_ref_sys.id', onupdate='CASCADE', ondelete='CASCADE'))
     classification_system_id = Column(ForeignKey(LucClassificationSystem.id, onupdate='CASCADE', ondelete='CASCADE'))
     collection_type = Column(enum_collection_type, nullable=False)
-    _metadata = Column('metadata', JSONB, comment='Follow the JSONSchema @jsonschemas/collection-metadata.json')
+    _metadata = Column('metadata', JSONSchemaType('collection-metadata.json'), comment='Follow the JSONSchema @jsonschemas/collection-metadata.json')
     is_public = Column(Boolean(), nullable=False, default=True)
     start_date = Column(TIMESTAMP(timezone=True))
     end_date = Column(TIMESTAMP(timezone=True))

--- a/bdc_catalog/models/item.py
+++ b/bdc_catalog/models/item.py
@@ -11,10 +11,10 @@
 from geoalchemy2 import Geometry
 from sqlalchemy import (TIMESTAMP, Column, ForeignKey, Index, Integer, Numeric,
                         String)
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
 from ..config import BDC_CATALOG_SCHEMA
+from ..types import JSONSchemaType
 from .base_sql import BaseModel, db
 from .collection import Collection
 
@@ -87,8 +87,8 @@ class Item(BaseModel):
     start_date = Column(TIMESTAMP(timezone=True), nullable=False)
     end_date = Column(TIMESTAMP(timezone=True), nullable=False)
     cloud_cover = Column(Numeric)
-    assets = Column(JSONB, comment='Follow the JSONSchema @jsonschemas/item-assets.json')
-    _metadata = Column('metadata', JSONB, comment='Follow the JSONSchema @jsonschemas/item-metadata.json')
+    assets = Column(JSONSchemaType('item-assets.json'), comment='Follow the JSONSchema @jsonschemas/item-assets.json')
+    _metadata = Column('metadata', JSONSchemaType('item-metadata.json'), comment='Follow the JSONSchema @jsonschemas/item-metadata.json')
     provider_id = Column(ForeignKey(f'{BDC_CATALOG_SCHEMA}.providers.id', onupdate='CASCADE', ondelete='CASCADE'))
     application_id = Column(ForeignKey(f'{BDC_CATALOG_SCHEMA}.applications.id', onupdate='CASCADE', ondelete='CASCADE'))
     geom = Column(Geometry(geometry_type='Polygon', srid=4326, spatial_index=False))

--- a/bdc_catalog/types.py
+++ b/bdc_catalog/types.py
@@ -1,0 +1,48 @@
+#
+# This file is part of Brazil Data Cube Database module.
+# Copyright (C) 2019 INPE.
+#
+# Brazil Data Cube Database module is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+
+"""Represent the custom data types for BDC-Catalog."""
+
+from typing import Any
+
+from sqlalchemy import TypeDecorator
+from sqlalchemy.dialects.postgresql import JSONB
+
+from .utils import validate_schema
+
+
+class JSONSchemaType(TypeDecorator):
+    """Custom Data Type for dealing with JSONB and JSONSchemas on SQLAlchemy."""
+
+    _schema_key: str
+    _draft_checker: Any
+    impl = JSONB
+
+    def __init__(self, schema: str, draft_checker=None, *args, **kwargs):
+        """Build a new data type."""
+        self._schema_key = schema
+        self._draft_checker = draft_checker
+        super().__init__(*args, **kwargs)
+
+    def coerce_compared_value(self, op, value):
+        """Define a 'coerced' Python value in an expression.
+
+        Note:
+            Implements native SQLAlchemy :class:`~sqlalchemy.dialects.postgresql.JSONB`.
+        """
+        return self.impl.coerce_compared_value(op, value)
+
+    def process_bind_param(self, value, dialect):
+        """Apply JSONSchema validation and bind the JSON value to the SQLAlchemy Engine execution."""
+        options = dict()
+        if self._draft_checker:
+            options['draft_checker'] = self._draft_checker
+        if value is not None:
+            validate_schema(self._schema_key, value, **options)
+
+        return value

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ install_requires = [
     'Flask-SQLAlchemy>=2.4.0',
     'Flask-Alembic>=2.0.0',
     'invenio-jsonschemas==1.1.3',
+    'jsonschema>=3,<4',
     'GeoAlchemy2>=0.8.4',
     'SQLAlchemy[postgresql_psycopg2binary]>=1.3,<1.4',
     'SQLAlchemy-Utils>=0.36.0',

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ install_requires = [
     'Flask>=1.1.0',
     'Flask-SQLAlchemy>=2.4.0',
     'Flask-Alembic>=2.0.0',
+    'invenio-jsonschemas==1.1.3',
     'GeoAlchemy2>=0.8.4',
     'SQLAlchemy[postgresql_psycopg2binary]>=1.3,<1.4',
     'SQLAlchemy-Utils>=0.36.0',
@@ -91,6 +92,9 @@ setup(
         ],
         'bdc_db.namespaces': [
             'bdc_catalog = bdc_catalog.config:BDC_CATALOG_SCHEMA'
+        ],
+        'bdc.schemas': [
+            'bdc_catalog = bdc_catalog.jsonschemas'
         ],
         'console_scripts': [
             'bdc-catalog = bdc_catalog.cli:cli'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,8 @@ from tempfile import TemporaryDirectory
 
 import multihash
 
-from bdc_catalog.utils import multihash_checksum_sha256
+from bdc_catalog.ext import BDCCatalog
+from bdc_catalog.utils import multihash_checksum_sha256, validate_schema
 
 
 def test_check_sum_sha256():
@@ -39,3 +40,23 @@ def test_check_sum_sha256():
 
         # Ensure digest is a multihash
         assert multihash.is_valid(digest)
+
+
+def test_validate_json_schema(app):
+    """Test minimal json schema validator."""
+    _ = BDCCatalog(app)
+
+    date_str = "2020-01-01T00:00:00"
+    assets = dict(
+        thumbnail={
+            'href': 'http://fakehost/file.png',
+            'type': 'image/png',
+            'created': date_str,
+            'updated': date_str,
+            'roles': ['thumbnail'],
+            'checksum:multihash': '1208abcd',
+            'bdc:size': 0
+        }
+    )
+
+    validate_schema('item-assets.json', assets)


### PR DESCRIPTION
This PR is a way to deal with JSONB columns validation using a custom data type `JSONSchemaType`.

Please review this if it should be attached into `bdc-db` instead.
I believe we should adapt the `ValidationError` from `jsonschemas.validate` to be more clean and easy to understand.